### PR TITLE
Fix file deletion flag and drop handling

### DIFF
--- a/api.php
+++ b/api.php
@@ -281,7 +281,7 @@ if ($action === 'download') {
     header('Content-Length: ' . filesize($filePath));
     readfile($filePath);
     // **Jetzt direkt löschen**
-    if ($preserveFile) { unlink($filePath); }
+    if (!$preserveFile) { unlink($filePath); }
 
     // (Optional: Datei nach Download löschen? Oder separat per delete!)
     exit;

--- a/index.php
+++ b/index.php
@@ -130,7 +130,10 @@ $pwFromUrl = getPasswordFromUrl();
 
     document.body.addEventListener('dragover', e => { e.preventDefault(); document.getElementById('drop-area').classList.add('highlight'); });
     document.body.addEventListener('dragleave', e => { e.preventDefault(); document.getElementById('drop-area').classList.remove('highlight'); });
-    document.body.addEventListener('drop', e => { document.getElementById('drop-area').classList.remove('highlight'); });
+    document.body.addEventListener('drop', e => {
+        e.preventDefault();
+        document.getElementById('drop-area').classList.remove('highlight');
+    });
 
     let r = new Resumable({
         target: '/action/upload',


### PR DESCRIPTION
## Summary
- prevent default browser behavior on file drop
- correct logic for `preserve` parameter during download

## Testing
- `php -l api.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4c8e66c8323bef5acb1471cf06f