### PR TITLE
Add password prompt for downloads

### DIFF
--- a/download.php
+++ b/download.php
@@ -32,12 +32,33 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
 <script>
     const token = "<?= htmlspecialchars($token) ?>";
 
-    const password = "<?= htmlspecialchars($password) ?>"
+    let password = "<?= htmlspecialchars($password) ?>"
     const highlightFile = "<?= htmlspecialchars($fileHighlight) ?>"
     const alertBox = document.getElementById('alertBox');
     const filesBox = document.getElementById('filesBox');
     const actionBox = document.getElementById('actionBox');
+    const backLink = document.querySelector('.mt-5 a.link-secondary');
     let files = [];
+    updateBackLink();
+
+    function updateBackLink() {
+        if (backLink) {
+            backLink.href = '/' + encodeURIComponent(token) + (password ? '/' + encodeURIComponent(password) : '');
+        }
+    }
+
+    function showPasswordPrompt(msg) {
+        alertBox.innerHTML = `<div class="alert alert-warning text-center">${msg}<br>` +
+            `<div class="input-group mt-2"><input type="password" class="form-control" id="pwInput" placeholder="Password">` +
+            `<button class="btn btn-primary" id="pwSubmit">OK</button></div></div>`;
+        filesBox.innerHTML = '';
+        actionBox.innerHTML = '';
+        document.getElementById('pwSubmit').onclick = function () {
+            password = document.getElementById('pwInput').value.trim();
+            updateBackLink();
+            fetchFiles();
+        };
+    }
 
     // 1. Files laden
     function fetchFiles() {
@@ -49,9 +70,13 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
             .then(r => r.json())
             .then(data => {
                 if (data.error) {
-                    alertBox.innerHTML = `<div class="alert alert-danger text-center">${data.error}</div>`;
-                    filesBox.innerHTML = '';
-                    actionBox.innerHTML = '';
+                    if (data.error.toLowerCase().includes('password')) {
+                        showPasswordPrompt(data.error);
+                    } else {
+                        alertBox.innerHTML = `<div class="alert alert-danger text-center">${data.error}</div>`;
+                        filesBox.innerHTML = '';
+                        actionBox.innerHTML = '';
+                    }
                     return;
                 }
                 files = data.files || [];


### PR DESCRIPTION
## Summary
- improve download.php to allow entering a password when needed

## Testing
- `php -l download.php`
- `php -l index.php`
- `php -l api.php`


------
https://chatgpt.com/codex/tasks/task_e_6852ffba9c8c8323b71be32d17a74728