### PR TITLE
Add usable WebCrypto chunk encryption

### DIFF
--- a/example-encryption.js
+++ b/example-encryption.js
@@ -1,0 +1,38 @@
+// Example helper to encrypt Resumable.js chunks with WebCrypto
+// Call setupEncryption(resumable, password) before starting the upload.
+
+async function deriveKey(password) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(password), {name: 'PBKDF2'}, false, ['deriveKey']
+  );
+  const salt = enc.encode('static-salt'); // In production use a random salt stored with the file
+  return crypto.subtle.deriveKey(
+    {name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256'},
+    keyMaterial,
+    {name: 'AES-GCM', length: 256},
+    false,
+    ['encrypt']
+  );
+}
+
+function setupEncryption(resumable, password) {
+  const origQuery = resumable.opts.query;
+  return deriveKey(password).then(key => {
+    resumable.opts.query = function() {
+      let base = typeof origQuery === 'function' ? origQuery() : origQuery || {};
+      base.encrypted = 1;
+      return base;
+    };
+    resumable.opts.preprocess = async function(chunk) {
+      const buf = await chunk.file.slice(chunk.startByte, chunk.endByte).arrayBuffer();
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const cipher = await crypto.subtle.encrypt({name: 'AES-GCM', iv}, key, buf);
+      chunk.data = new Blob([iv, new Uint8Array(cipher)]);
+      chunk.size = chunk.data.size;
+      chunk.preprocessFinished();
+    };
+  });
+}
+
+if (typeof module !== 'undefined') module.exports = { setupEncryption };


### PR DESCRIPTION
## Summary
- update example-encryption.js with a reusable setupEncryption helper
- wire encryption checkbox and logic into index page
- send `encrypted=1` on upload when enabled and encrypt chunks before upload

## Testing
- `php -l api.php` *(fails: php not found)*
- `php -l download.php` *(fails: php not found)*
- `php -l index.php` *(fails: php not found)*
- `php -l upload.php` *(fails: php not found)*
- `node -e "require('./example-encryption.js')"`

------
https://chatgpt.com/codex/tasks/task_e_685a7d57cf888323a90a429a51a2d2eb