### PR TITLE
Prevent duplicate initialization from encrypted file

### DIFF
--- a/index.php
+++ b/index.php
@@ -347,6 +347,7 @@ $pwFromUrl = getPasswordFromUrl();
     r.assignBrowse(browseBtn);
 
     r.on('fileAdded', function (file) {
+        if (file.isEncrypted) return; // skip duplicate events
         resultBox.innerHTML = '';
         if (r.files.length === 1) uploadedFiles = [];
         let tInput = tokenInput.value.trim();


### PR DESCRIPTION
## Summary
- skip `fileAdded` events for encrypted files in `index.php`

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aaae648c083239db2d4c3c5148319