### PR TITLE
Add client-side decryption support

### DIFF
--- a/download.php
+++ b/download.php
@@ -43,6 +43,7 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/encryption.js?t=<?= time() ?>"></script>
 <script>
     const token = "<?= htmlspecialchars($token) ?>";
 
@@ -194,6 +195,40 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
         });
     }
 
+    function triggerDownload(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 100);
+    }
+
+    function downloadAndDecrypt(url, filename) {
+        fetch(url).then(resp => resp.blob().then(async b => {
+            if (resp.headers.get('X-Encrypted')) {
+                const buf = await b.arrayBuffer();
+                const dec = await decryptFile(buf, password);
+                triggerDownload(dec, filename);
+            } else {
+                triggerDownload(b, filename);
+            }
+        }));
+    }
+
+    function initDownloadLinks() {
+        document.querySelectorAll('.file-download-link').forEach(a => {
+            if (a.dataset.dlBound) return;
+            a.dataset.dlBound = '1';
+            a.addEventListener('click', e => {
+                e.preventDefault();
+                const fname = a.getAttribute('data-filename') || '';
+                downloadAndDecrypt(a.href, fname);
+            });
+        });
+    }
+
     function renderFiles() {
         if (!files.length) {
             filesBox.innerHTML = `<div class="alert alert-warning text-center">No files available.</div>`;
@@ -209,17 +244,18 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
             let downloadUrl = `/action/d/${encodeURIComponent(token)}/f/${encodeURIComponent(name)}${pwSeg}`;
             let previewUrl = `/action/d/${encodeURIComponent(token)}/f/${encodeURIComponent(name)}${pwSegFile}?preserve=true`;
             let ext = name.split('.').pop().toLowerCase();
+            let lock = f.encrypted ? ' \uD83D\uDD12' : '';
             html += `
 <div class="list-group-item py-2">
   <div class="row align-items-center flex-nowrap g-2">
     <div class="col-5 col-md-6 min-width-0">
-      <span class="d-block text-truncate" title="${name}">${name}</span>
+      <span class="d-block text-truncate" title="${name}">${name}${lock}</span>
     </div>
     <div class="col-3 col-md-3 text-end text-secondary small flex-shrink-0">
       ${size ? `(${size})` : ''}
     </div>
     <div class="col-4 col-md-3 text-end d-flex justify-content-end align-items-center gap-2 flex-nowrap flex-shrink-0">
-      <a href="${downloadUrl}" class="btn btn-outline-primary btn-sm" download title="Download">
+      <a href="${downloadUrl}" class="btn btn-outline-primary btn-sm file-download-link" data-filename="${name}" title="Download">
         <i class="bi bi-download"></i>
       </a>
       <button class="btn btn-outline-secondary btn-sm preview-btn" data-url="${previewUrl}" data-ext="${ext}" title="Preview">
@@ -280,6 +316,7 @@ $fileHighlight = isset($_GET['file']) ? urldecode($_GET['file']) : '';
             };
         });
         initPreviewButtons();
+        initDownloadLinks();
         // Alle löschen
         document.getElementById('deleteBtn').onclick = function () {
             if (!confirm('Really delete ALL files?')) return;

--- a/index.php
+++ b/index.php
@@ -375,6 +375,40 @@ $pwFromUrl = getPasswordFromUrl();
         });
     }
 
+    function triggerDownload(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 100);
+    }
+
+    function downloadAndDecrypt(url, filename) {
+        fetch(url).then(resp => resp.blob().then(async b => {
+            if (resp.headers.get('X-Encrypted')) {
+                const buf = await b.arrayBuffer();
+                const dec = await decryptFile(buf, passwordInput.value.trim());
+                triggerDownload(dec, filename);
+            } else {
+                triggerDownload(b, filename);
+            }
+        }));
+    }
+
+    function initDownloadLinks() {
+        document.querySelectorAll('.file-download-link').forEach(a => {
+            if (a.dataset.dlBound) return;
+            a.dataset.dlBound = '1';
+            a.addEventListener('click', e => {
+                e.preventDefault();
+                const fname = a.getAttribute('data-filename') || '';
+                downloadAndDecrypt(a.href, fname);
+            });
+        });
+    }
+
     r.assignDrop(dropArea);
     r.assignBrowse(browseBtn);
 
@@ -511,12 +545,13 @@ $pwFromUrl = getPasswordFromUrl();
             let fileUrl = `${baseUrl}/f/${encodeURIComponent(fn.name)}${pwSeg}`;
             let previewUrl = `${window.location.origin}/action/d/${encodeURIComponent(fn.token)}/f/${encodeURIComponent(fn.name)}${pwSegFile}?preserve=true`;
             let ext = fn.name.split('.').pop().toLowerCase();
+            let lock = fn.encrypted ? ' \uD83D\uDD12' : '';
             html += `
 <div class="input-group mb-2 download-row">
-  <input type="text" class="form-control form-control-sm dl-input" id="${fileLinkId}" value="${fn.name}" data-full-link="${fileUrl}" readonly>
+  <input type="text" class="form-control form-control-sm dl-input" id="${fileLinkId}" value="${fn.name}${lock}" data-full-link="${fileUrl}" readonly>
   <button class="btn btn-outline-secondary btn-sm copy-btn" type="button" data-clipboard-target="${fileLinkId}"><i class="bi bi-clipboard"></i></button>
   <button class="btn btn-outline-secondary btn-sm preview-btn" type="button" data-url="${previewUrl}" data-ext="${ext}" title="Preview"><i class="bi bi-eye"></i></button>
-  <a href="${fileUrl}" class="btn btn-outline-primary btn-sm file-download-link" target="_blank"><i class="bi bi-download"></i></a>
+  <a href="${fileUrl}" class="btn btn-outline-primary btn-sm file-download-link" data-filename="${fn.name}"><i class="bi bi-download"></i></a>
   <button class="delete-btn btn btn-outline-danger btn-sm" title="Delete file" data-file="${fn.name}" type="button"><i class="bi bi-trash"></i></button>
 </div>
 <div id="copyStatus-${fileLinkId}" class="small text-success mb-2" style="display:none;">File link copied!</div>`;
@@ -572,6 +607,7 @@ $pwFromUrl = getPasswordFromUrl();
             });
         });
         initPreviewButtons();
+        initDownloadLinks();
     }
 
     r.on('fileError', function (file, msg) {


### PR DESCRIPTION
## Summary
- enable decrypting downloads in the browser
- display a lock emoji next to encrypted files

## Testing
- `node -e "require('./encryption.js'); console.log('js ok');"`

------
https://chatgpt.com/codex/tasks/task_e_685ae020cb2c8323b829e3edfc69bd56