### PR TITLE
Fix deletion logic on index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -554,7 +554,8 @@ $pwFromUrl = getPasswordFromUrl();
         const pwSegFile = pwVal ? '/' + encodeURIComponent(pwVal) : '';
         data.files.forEach((fn, idx) => {
             let fileLinkId = 'fileDownloadLink_' + idx;
-            let fileUrl = `${baseUrl}/f/${encodeURIComponent(fn.name)}${pwSeg}`;
+            let shareUrl = `${baseUrl}/f/${encodeURIComponent(fn.name)}${pwSeg}`;
+            let downloadUrl = `${window.location.origin}/action/d/${encodeURIComponent(fn.token)}/f/${encodeURIComponent(fn.name)}${pwSegFile}`;
             let previewUrl = `${window.location.origin}/action/d/${encodeURIComponent(fn.token)}/f/${encodeURIComponent(fn.name)}${pwSegFile}?preserve=true`;
             let ext = fn.name.split('.').pop().toLowerCase();
             let lock = fn.encrypted ? ' \uD83D\uDD12' : '';
@@ -562,11 +563,11 @@ $pwFromUrl = getPasswordFromUrl();
             let previewsymbol = fn.encrypted ? 'bi bi-eye-slash' : 'bi bi-eye';
             html += `
 <div class="input-group mb-2 download-row">
-  <input type="text" class="form-control form-control-sm dl-input" id="${fileLinkId}" value="${fn.name}${lock}" data-full-link="${fileUrl}" readonly>
+  <input type="text" class="form-control form-control-sm dl-input" id="${fileLinkId}" value="${fn.name}${lock}" data-full-link="${shareUrl}" readonly>
   <button class="btn btn-outline-secondary btn-sm copy-btn" type="button" data-clipboard-target="${fileLinkId}"><i class="bi bi-clipboard"></i></button>
 
   <button class="btn btn-outline-secondary btn-sm preview-btn${fn.encrypted ? ' disabled' : ''}" type="button" data-url="${previewUrl}" data-ext="${ext}" title="Preview"><i class="${previewsymbol}"></i></button>
-  <a href="${fileUrl}" class="btn btn-outline-primary btn-sm file-download-link" data-filename="${fn.name}"><i class="bi bi-download"></i></a>
+  <a href="${downloadUrl}" class="btn btn-outline-primary btn-sm file-download-link" data-filename="${fn.name}"><i class="bi bi-download"></i></a>
   <button class="delete-btn btn btn-outline-danger btn-sm" title="Delete file" data-file="${fn.name}" type="button"><i class="bi bi-trash"></i></button>
 </div>
 <div id="copyStatus-${fileLinkId}" class="small text-success mb-2" style="display:none;">File link copied!</div>`;


### PR DESCRIPTION
## Summary
- ensure files downloaded from `index.php` use the same API endpoint as `download.php`
- keep share links pointing to the download page

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aee24c290832392b4547b0a79d98c