### PR TITLE
Fix note destruction view for encrypted notes

### DIFF
--- a/note.php
+++ b/note.php
@@ -210,64 +210,6 @@ if ($token) {
         <?php
         exit;
     }
-    if (!isset($_GET['view'])) {
-        $base = '/note/' . rawurlencode($token);
-        if ($password !== '') $base .= '/' . rawurlencode($password);
-        $viewLink = $base . '?view=1';
-        ?>
-        <!DOCTYPE html>
-        <html lang="en" data-bs-theme="light">
-        <head>
-            <meta charset="UTF-8">
-            <title>View Note</title>
-            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-            <script>
-                (function(){
-                    const stored = localStorage.getItem('theme');
-                    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                    const theme = stored || (prefersDark ? 'dark' : 'light');
-                    document.documentElement.setAttribute('data-bs-theme', theme);
-                })();
-            </script>
-        </head>
-        <body>
-        <button id="themeToggle" type="button" class="btn btn-outline-secondary btn-sm position-fixed top-0 end-0 m-3" title="Toggle dark mode"><i class="bi bi-moon-fill"></i></button>
-        <div class="container" style="max-width:600px;margin-top:2em;">
-            <div class="alert alert-info text-center">This note will self-destruct after you view it.</div>
-            <div class="text-center mt-4">
-                <a href="<?= htmlspecialchars($viewLink) ?>" id="viewBtn" class="btn btn-primary">Read and Destroy Note</a>
-            </div>
-        </div>
-        <script>
-        document.addEventListener('DOMContentLoaded', function(){
-            var l = document.getElementById('viewBtn');
-            if(l) l.href += location.hash;
-        });
-        </script>
-        <script>
-            const themeToggleBtn = document.getElementById('themeToggle');
-            function applyTheme(theme){
-                document.documentElement.setAttribute('data-bs-theme', theme);
-                themeToggleBtn.innerHTML = theme === 'dark'
-                    ? '<i class="bi bi-sun-fill"></i>'
-                    : '<i class="bi bi-moon-fill"></i>';
-            }
-            document.addEventListener('DOMContentLoaded', function(){
-                applyTheme(document.documentElement.getAttribute('data-bs-theme'));
-                themeToggleBtn.addEventListener('click', function(){
-                    const current = document.documentElement.getAttribute('data-bs-theme');
-                    const next = current === 'dark' ? 'light' : 'dark';
-                    localStorage.setItem('theme', next);
-                    applyTheme(next);
-                });
-            });
-        </script>
-        </body>
-        </html>
-        <?php
-        exit;
-    }
     $meta = load_meta($token);
     $isEnc = !empty($meta['encrypted']);
     if (!isset($_GET['view'])) {


### PR DESCRIPTION
## Summary
- remove obsolete non-encrypted view block in `note.php`
- ensure encrypted notes work when clicking **Read and Destroy Note**

## Testing
- `php -l note.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc65ea19083239d1014588fed7040