### PR TITLE
Handle note decryption key in URL hash

### DIFF
--- a/note.php
+++ b/note.php
@@ -242,16 +242,28 @@ if ($token) {
         document.addEventListener('DOMContentLoaded', function(){
 <?php if ($isEnc): ?>
             const f = document.getElementById('viewForm');
-            f.addEventListener('submit', async function(e){
-                e.preventDefault();
-                const key = document.getElementById('formKey').value.trim();
-                if(!key){alert('Enter decryption key'); return;}
+
+            async function submitWithKey(key){
                 const bytes = Uint8Array.from(atob(key), c => c.charCodeAt(0));
                 const digest = await crypto.subtle.digest('SHA-256', bytes);
                 const hashStr = btoa(String.fromCharCode(...new Uint8Array(digest)));
                 document.getElementById('formHash').value = hashStr;
                 location.hash = key;
                 f.submit();
+            }
+
+            const hashKey = location.hash.slice(1);
+            if(hashKey){
+                f.style.display = 'none';
+                submitWithKey(hashKey);
+                return;
+            }
+
+            f.addEventListener('submit', async function(e){
+                e.preventDefault();
+                const key = document.getElementById('formKey').value.trim();
+                if(!key){alert('Enter decryption key'); return;}
+                await submitWithKey(key);
             });
 <?php else: ?>
             // append any hash to button link
@@ -297,16 +309,28 @@ if ($token) {
             <script>
             document.addEventListener('DOMContentLoaded', function(){
                 const f = document.getElementById('viewForm');
-                f.addEventListener('submit', async function(e){
-                    e.preventDefault();
-                    const key = document.getElementById('formKey').value.trim();
-                    if(!key){alert('Enter decryption key'); return;}
+
+                async function submitWithKey(key){
                     const bytes = Uint8Array.from(atob(key), c => c.charCodeAt(0));
                     const digest = await crypto.subtle.digest('SHA-256', bytes);
                     const hashStr = btoa(String.fromCharCode(...new Uint8Array(digest)));
                     document.getElementById('formHash').value = hashStr;
                     location.hash = key;
                     f.submit();
+                }
+
+                const hashKey = location.hash.slice(1);
+                if(hashKey){
+                    f.style.display = 'none';
+                    submitWithKey(hashKey);
+                    return;
+                }
+
+                f.addEventListener('submit', async function(e){
+                    e.preventDefault();
+                    const key = document.getElementById('formKey').value.trim();
+                    if(!key){alert('Enter decryption key'); return;}
+                    await submitWithKey(key);
                 });
             });
             </script>


### PR DESCRIPTION
## Summary
- improve encrypted note workflow
- if key is already in the URL hash, auto-submit the form
- when user types a key, append it to the URL hash before submitting

## Testing
- `php -l note.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc897ff5c8323821162f69a9b9068