### PR TITLE
Fix dark mode on note viewing

### DIFF
--- a/note.php
+++ b/note.php
@@ -218,13 +218,23 @@ if ($token) {
         $viewAction = $base;
         ?>
         <!DOCTYPE html>
-        <html lang="en">
+        <html lang="en" data-bs-theme="light">
         <head>
             <meta charset="UTF-8">
             <title>View Note</title>
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+            <script>
+                (function(){
+                    const stored = localStorage.getItem('theme');
+                    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    const theme = stored || (prefersDark ? 'dark' : 'light');
+                    document.documentElement.setAttribute('data-bs-theme', theme);
+                })();
+            </script>
         </head>
         <body>
+        <button id="themeToggle" type="button" class="btn btn-outline-secondary btn-sm position-fixed top-0 end-0 m-3" title="Toggle dark mode"><i class="bi bi-moon-fill"></i></button>
         <div class="container" style="max-width:600px;margin-top:2em;">
             <div class="alert alert-info text-center">This note will self-destruct after you view it.</div>
             <form id="viewForm" method="get" action="<?= htmlspecialchars($viewAction) ?>" class="mt-4 text-center">
@@ -258,6 +268,24 @@ if ($token) {
 <?php endif; ?>
         });
         </script>
+        <script>
+            const themeToggleBtn = document.getElementById('themeToggle');
+            function applyTheme(theme){
+                document.documentElement.setAttribute('data-bs-theme', theme);
+                themeToggleBtn.innerHTML = theme === 'dark'
+                    ? '<i class="bi bi-sun-fill"></i>'
+                    : '<i class="bi bi-moon-fill"></i>';
+            }
+            document.addEventListener('DOMContentLoaded', function(){
+                applyTheme(document.documentElement.getAttribute('data-bs-theme'));
+                themeToggleBtn.addEventListener('click', function(){
+                    const current = document.documentElement.getAttribute('data-bs-theme');
+                    const next = current === 'dark' ? 'light' : 'dark';
+                    localStorage.setItem('theme', next);
+                    applyTheme(next);
+                });
+            });
+        </script>
         </body>
         </html>
         <?php
@@ -276,13 +304,23 @@ if ($token) {
             $msg = 'Wrong decryption key.';
             ?>
             <!DOCTYPE html>
-            <html lang="en">
+            <html lang="en" data-bs-theme="light">
             <head>
                 <meta charset="UTF-8">
                 <title>View Note</title>
                 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+                <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+                <script>
+                    (function(){
+                        const stored = localStorage.getItem('theme');
+                        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                        const theme = stored || (prefersDark ? 'dark' : 'light');
+                        document.documentElement.setAttribute('data-bs-theme', theme);
+                    })();
+                </script>
             </head>
             <body>
+            <button id="themeToggle" type="button" class="btn btn-outline-secondary btn-sm position-fixed top-0 end-0 m-3" title="Toggle dark mode"><i class="bi bi-moon-fill"></i></button>
             <div class="container" style="max-width:600px;margin-top:2em;">
                 <div class="alert alert-danger text-center"><?= htmlspecialchars($msg) ?></div>
                 <form id="viewForm" method="get" action="<?= htmlspecialchars($viewAction) ?>" class="mt-4 text-center">
@@ -307,6 +345,24 @@ if ($token) {
                     document.getElementById('formHash').value = hashStr;
                     location.hash = key;
                     f.submit();
+                });
+            });
+            </script>
+            <script>
+            const themeToggleBtn = document.getElementById('themeToggle');
+            function applyTheme(theme){
+                document.documentElement.setAttribute('data-bs-theme', theme);
+                themeToggleBtn.innerHTML = theme === 'dark'
+                    ? '<i class="bi bi-sun-fill"></i>'
+                    : '<i class="bi bi-moon-fill"></i>';
+            }
+            document.addEventListener('DOMContentLoaded', function(){
+                applyTheme(document.documentElement.getAttribute('data-bs-theme'));
+                themeToggleBtn.addEventListener('click', function(){
+                    const current = document.documentElement.getAttribute('data-bs-theme');
+                    const next = current === 'dark' ? 'light' : 'dark';
+                    localStorage.setItem('theme', next);
+                    applyTheme(next);
                 });
             });
             </script>


### PR DESCRIPTION
## Summary
- re-add dark mode support for the intermediate note view pages

## Testing
- `php -l note.php` *(fails: command not found)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685bc8b462f88323936b7157cb8653d7