### PR TITLE
Fix missing encryption key on note view

### DIFF
--- a/note.php
+++ b/note.php
@@ -255,7 +255,7 @@ if ($token) {
                 const digest = await crypto.subtle.digest('SHA-256', bytes);
                 const hashStr = btoa(String.fromCharCode(...new Uint8Array(digest)));
                 document.getElementById('formHash').value = hashStr;
-                location.hash = key;
+                f.action = f.action.split('#')[0] + '#' + encodeURIComponent(key);
                 f.submit();
             }
 
@@ -350,7 +350,7 @@ if ($token) {
                     const digest = await crypto.subtle.digest('SHA-256', bytes);
                     const hashStr = btoa(String.fromCharCode(...new Uint8Array(digest)));
                     document.getElementById('formHash').value = hashStr;
-                    location.hash = key;
+                    f.action = f.action.split('#')[0] + '#' + encodeURIComponent(key);
                     f.submit();
                 }
 


### PR DESCRIPTION
## Summary
- ensure encryption key fragment is included when submitting to view a note

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbbfe7a483239afdcd94b9ae9d34