### PR TITLE
Ensure note is removed only after successful read

### DIFF
--- a/note.php
+++ b/note.php
@@ -395,9 +395,13 @@ if ($token) {
     }
 
     $note = file_get_contents($noteFile);
-    unlink($noteFile);
-    if (file_exists(token_meta($token))) unlink(token_meta($token));
-    delete_token_dir_if_empty($token);
+    if ($note !== false) {
+        unlink($noteFile);
+        if (file_exists(token_meta($token))) unlink(token_meta($token));
+        delete_token_dir_if_empty($token);
+    } else {
+        $note = '';
+    }
     ?>
     <!DOCTYPE html>
     <html lang="en" data-bs-theme="light">


### PR DESCRIPTION
## Summary
- safeguard note deletion with a check that `file_get_contents` succeeded

## Testing
- `php -l note.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bced54188832381a1769c278e50e6