### PR TITLE
Fix note decryption error display

### DIFF
--- a/note.php
+++ b/note.php
@@ -293,7 +293,7 @@ if ($token) {
             ?>
             <?php page_header('View Note'); ?>
             <div class="container" style="max-width:600px;margin-top:2em;">
-                <div id="errBox" class="alert alert-danger text-center" style="display:none;">
+                <div id="errBox" class="alert alert-danger text-center">
                     <?= htmlspecialchars($msg) ?>
                 </div>
                 <form id="viewForm" method="get" action="<?= htmlspecialchars($viewAction) ?>" class="mt-4 text-center">


### PR DESCRIPTION
## Summary
- show wrong decryption key message by default so user can re-enter key

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bea61b2608323832b5bfd670b40d0